### PR TITLE
chore: add FOSSA config for license compliance (example-python-fork)

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,0 +1,11 @@
+version: 3
+
+# FOSSA CLI for getsentry/action-enforce-license-compliance.
+# https://github.com/fossas/fossa-cli/blob/master/docs/references/files/fossa-yml.md
+
+project:
+  id: github.com/codecov/example-python-fork
+  url: https://github.com/codecov/example-python-fork
+
+telemetry:
+  scope: "off"

--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -4,6 +4,7 @@ name: Enforce License Compliance
 on:
   pull_request:
     branches: [main, master]
+  workflow_dispatch:
 
 jobs:
   enforce-license-compliance:


### PR DESCRIPTION
Adds `.fossa.yml` (FOSSA CLI v3 project metadata, telemetry off) and, when the repo has no root Python manifest, a minimal `requirements.txt` so `fossa analyze` discovers a setuptools target. Triggers **Enforce License Compliance** on PR.